### PR TITLE
Fix http request name

### DIFF
--- a/cccp.go
+++ b/cccp.go
@@ -141,7 +141,7 @@ func SetFromHTTPRequestToFile(src *http.Request, dst, name string) error {
 	}
 
 	if name == "" {
-		name = path.Base(src.RequestURI)
+		name = path.Base(src.URL.Path)
 	}
 
 	s, err := source.NewHTTPRequest(src)


### PR DESCRIPTION
When the request URL is with queries (e.g. http://example.com/file01?q=1), display the base part of the path (e.g. file01) excluding queries to the progress bar.